### PR TITLE
Add UTF-8 support for Microsoft webcams

### DIFF
--- a/webcamdialog.bat
+++ b/webcamdialog.bat
@@ -1,2 +1,3 @@
+chcp 65001 > nul
 set cam="YOUR WEBCAM NAME"
 ffmpeg -f dshow -show_video_device_dialog true -i video=%cam%


### PR DESCRIPTION
My webcam is "Microsoft® LifeCam HD-3000". Due to registered trademark symbol, switching default code page of Windows console is needed to make it work.